### PR TITLE
Add functionality to manage system-db keys and system-db locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,38 @@ This module simply ensures that dconf is installed; a profile is added; and that
 
 dconf is used for low-level configuration and settings management.
 
-This module does not manage any configuration itself - it merely ensured dconf is installed.
+This module also allows to manage system-db contents (key files and locks). For more information on dconf, have a look at [this dconf overview](https://developer.gnome.org/dconf/unstable/dconf-overview.html).
+
+This module depends on the following puppet modules:
+
+- [puppetlabs-stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
+- [puppetlabs-inifile](https://github.com/puppetlabs/puppetlabs-inifile)
+
+## Usage
+
+Using this module without setting system-db contents just requires 
+
+```puppet
+include dconf_profile
+```
+
+An example how to set a system-db key is
+
+```puppet
+dconf_profile::systemdb { 'background picture':
+        schema          => 'org/gnome/desktop/background',
+        key             => 'picture-uri',
+        value           => "'file:///path/to/background.png'",
+}
+```
+
+An example how to set a system-db lock is
+
+```puppet
+dconf_profile::systemdb::lock { 'background lock':
+        keys            => ['/org/gnome/desktop/background'],
+}
+```
 
 ## Parameters
 
@@ -21,7 +52,7 @@ None.
 
 ## Limitations
 
-Tested on Ubuntu 14.04 64bit/32bit.
+Tested on Ubuntu 14.04 64bit/32bit and Ubuntu 16.04 64bit.
 
 ## Release Notes/Contributors/Etc 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,4 +17,8 @@ class dconf_profile {
     source => 'puppet:///modules/dconf_profile/dconf_profile',
   }
 
+  exec { '/usr/bin/dconf update':
+    refreshonly => true,
+  }
+
 }

--- a/manifests/systemdb.pp
+++ b/manifests/systemdb.pp
@@ -1,0 +1,22 @@
+define dconf_profile::systemdb(
+	$schema		= $name,
+	$key		= undef,
+	$value		= undef,
+	$keyfilename	= '10-puppet-managed-settings',
+) {
+
+	if (($schema != undef) and ($key != undef) and ($value != undef) and ($keyfilename != undef)) {
+		ini_setting { "$schema/$key":
+			ensure		=> present,
+			path		=> "/etc/dconf/db/local.d/$keyfilename",
+			section		=> $schema,
+			setting		=> $key,
+			value		=> $value,
+			notify		=> Exec['/usr/bin/dconf update'],
+		}
+	}
+	else {
+		fail('dconf_profile::systemdb: At least one parameter is undefined')
+	}
+
+}

--- a/manifests/systemdb/lock.pp
+++ b/manifests/systemdb/lock.pp
@@ -1,0 +1,23 @@
+define dconf_profile::systemdb::lock(
+	$keys		= undef,
+	$lockfilename	= '10-puppet-managed-settings',
+) {
+
+	if ($keys != undef) {
+		validate_array($keys)
+	}
+	else {
+		fail('dconf_profile::systemdb::lock: keys array empty')
+	}
+	$filename 	= "/etc/dconf/db/local.d/locks/$lockfilename"
+	validate_absolute_path($filename)
+	
+	file { $filename:
+		owner		=> root,
+		group		=> root,
+		mode		=> 0644,
+		content		=> template("${module_name}/lock.erb"),
+		notify		=> Exec['/usr/bin/dconf update'],
+	}
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
   "project_page": null,
   "issues_url": null,
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.0.0"}
   ]
 }
 

--- a/templates/lock.erb
+++ b/templates/lock.erb
@@ -1,0 +1,4 @@
+# This file is managed by Puppet. DO NOT EDIT.
+<% keys.each do |key| -%>
+	<%= key %>
+<% end -%>


### PR DESCRIPTION
Add functionality to manage system-db keys and system-db locks. Examples how to use these features are included in the README.md file.
