### PR TITLE
systemdb::lock: File mode specifications must be string, not int.

### DIFF
--- a/manifests/systemdb/lock.pp
+++ b/manifests/systemdb/lock.pp
@@ -9,13 +9,13 @@ define dconf_profile::systemdb::lock(
 	else {
 		fail('dconf_profile::systemdb::lock: keys array empty')
 	}
-	$filename 	= "/etc/dconf/db/local.d/locks/$lockfilename"
+	$filename = "/etc/dconf/db/local.d/locks/$lockfilename"
 	validate_absolute_path($filename)
 	
 	file { $filename:
 		owner		=> root,
 		group		=> root,
-		mode		=> 0644,
+		mode		=> '0644',
 		content		=> template("${module_name}/lock.erb"),
 		notify		=> Exec['/usr/bin/dconf update'],
 	}


### PR DESCRIPTION
This fixes the Puppet error message:
```
The file mode specification must be a string, not 'Integer' (file: /etc/puppetlabs/code/environments/production/modules/profile/manifests/dconf_settings.pp, line: 38)
```
Reasoning by puppet devs is that file modes starting with 0 may be read as octal numbers. 