### PR TITLE
lock.erb: Fix template syntax.

### DIFF
--- a/templates/lock.erb
+++ b/templates/lock.erb
@@ -1,4 +1,4 @@
 # This file is managed by Puppet. DO NOT EDIT.
-<% keys.each do |key| -%>
+<% @keys.each do |key| -%>
 	<%= key %>
 <% end -%>


### PR DESCRIPTION
In modern puppet, either @-prefix or scope.lookupvar
has to be used.