### PR TITLE
 Add workaround for "dconf update" issue

### DIFF
--- a/manifests/systemdb.pp
+++ b/manifests/systemdb.pp
@@ -12,6 +12,10 @@ define dconf_profile::systemdb(
 			section		=> $schema,
 			setting		=> $key,
 			value		=> $value,
+		}~>
+		exec { 'touch /etc/dconf/db/local.d':
+			# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
+			refreshonly	=> true,
 			notify		=> Exec['/usr/bin/dconf update'],
 		}
 	}

--- a/manifests/systemdb.pp
+++ b/manifests/systemdb.pp
@@ -12,12 +12,15 @@ define dconf_profile::systemdb(
 			section		=> $schema,
 			setting		=> $key,
 			value		=> $value,
-		}~>
-		exec { 'touch /etc/dconf/db/local.d':
-			# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
-			refreshonly	=> true,
-			notify		=> Exec['/usr/bin/dconf update'],
+			notify		=> Exec['touch /etc/dconf/db/local.d'],
 		}
+		# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
+		ensure_resource('exec', 'touch /etc/dconf/db/local.d',
+			{
+				refreshonly	=> true,
+				notify		=> Exec['/usr/bin/dconf update'],
+			}
+		)
 	}
 	else {
 		fail('dconf_profile::systemdb: At least one parameter is undefined')

--- a/manifests/systemdb/lock.pp
+++ b/manifests/systemdb/lock.pp
@@ -15,11 +15,14 @@ define dconf_profile::systemdb::lock(
 		group		=> root,
 		mode		=> 0644,
 		content		=> template("${module_name}/lock.erb"),
-	}~>
-	exec { 'touch /etc/dconf/db/local.d/locks':
-		# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
-		refreshonly	=> true,
-		notify		=> Exec['/usr/bin/dconf update'],
+		notify		=> Exec['touch /etc/dconf/db/local.d/locks'],
 	}
+	# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
+	ensure_resource('exec', 'touch /etc/dconf/db/local.d/locks',
+		{
+			refreshonly	=> true,
+			notify		=> Exec['/usr/bin/dconf update'],
+		}
+	)
 
 }

--- a/manifests/systemdb/lock.pp
+++ b/manifests/systemdb/lock.pp
@@ -9,14 +9,16 @@ define dconf_profile::systemdb::lock(
 	else {
 		fail('dconf_profile::systemdb::lock: keys array empty')
 	}
-	$filename 	= "/etc/dconf/db/local.d/locks/$lockfilename"
-	validate_absolute_path($filename)
 	
-	file { $filename:
+	file { "/etc/dconf/db/local.d/locks/${lockfilename}":
 		owner		=> root,
 		group		=> root,
 		mode		=> 0644,
 		content		=> template("${module_name}/lock.erb"),
+	}~>
+	exec { 'touch /etc/dconf/db/local.d/locks':
+		# Workaround for https://gitlab.gnome.org/GNOME/dconf/issues/11 .
+		refreshonly	=> true,
 		notify		=> Exec['/usr/bin/dconf update'],
 	}
 


### PR DESCRIPTION
Upstream issue:
https://gitlab.gnome.org/GNOME/dconf/issues/11
is still present in versions currently available on LTS distros.
Since Puppet only modifies the systemdb files in-place and the mtime
of the containing directories is unchanged, "dconf update"
only works once without this trick.