### PR TITLE
Require dconf-cli to be installed before running dconf update.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,7 @@ class dconf_profile {
 
   exec { '/usr/bin/dconf update':
     refreshonly => true,
+    require     => Package['dconf-cli'],
   }
 
 }


### PR DESCRIPTION
Without ensuring correct order, the error:
```
puppet-agent[548]: (/Stage[main]/Dconf_profile/Exec[/usr/bin/dconf update]) Failed to call refresh: Could not find command '/usr/bin/dconf'
puppet-agent[548]: (/Stage[main]/Dconf_profile/Exec[/usr/bin/dconf update]) Could not find command '/usr/bin/dconf'
```
is sometimes observed. 